### PR TITLE
fix: support maxSize set null and deal with ENOENT error issue when rotated in pm2 cluster mode

### DIFF
--- a/src/logger/logger.ts
+++ b/src/logger/logger.ts
@@ -1,16 +1,16 @@
-import { transports, format } from 'winston';
+import { format, transports } from 'winston';
 import { DailyRotateFileTransport } from '../transport/rotate';
 import {
-  LoggerLevel,
-  LoggerOptions,
-  IMidwayLogger,
-  MidwayTransformableInfo,
-  LoggerCustomInfoHandler,
   ChildLoggerOptions,
   ContextLoggerOptions,
+  IMidwayLogger,
+  LoggerCustomInfoHandler,
+  LoggerLevel,
+  LoggerOptions,
+  MidwayTransformableInfo,
 } from '../interface';
 import { EmptyTransport } from '../transport';
-import { displayLabels, displayCommonMessage, customJSON } from '../format';
+import { customJSON, displayCommonMessage, displayLabels } from '../format';
 import * as os from 'os';
 import { basename, dirname, isAbsolute, join } from 'path';
 import * as util from 'util';
@@ -47,6 +47,16 @@ const midwayLogLevels = {
   silly: 7,
   all: 8,
 };
+
+function getMaxSize(...args) {
+  for (let i = 0; i <= args.length; i++) {
+    if (args[i] === undefined) {
+      continue;
+    }
+    return args[i];
+  }
+  return null;
+}
 
 /**
  *  base logger with console transport and file transport
@@ -215,10 +225,11 @@ export class MidwayBaseLogger extends WinstonLogger implements IMidwayLogger {
           this.loggerOptions.disableSymlink
         ),
         symlinkName: this.loggerOptions.fileLogName,
-        maxSize:
-          this.loggerOptions.fileMaxSize ||
-          this.loggerOptions.maxSize ||
-          '200m',
+        maxSize: getMaxSize(
+          this.loggerOptions.fileMaxSize,
+          this.loggerOptions.maxSize,
+          '200m'
+        ),
         maxFiles:
           this.loggerOptions.fileMaxFiles ||
           this.loggerOptions.maxFiles ||
@@ -253,8 +264,11 @@ export class MidwayBaseLogger extends WinstonLogger implements IMidwayLogger {
           this.loggerOptions.disableSymlink
         ),
         symlinkName: this.loggerOptions.errorLogName,
-        maxSize:
-          this.loggerOptions.errMaxSize || this.loggerOptions.maxSize || '200m',
+        maxSize: getMaxSize(
+          this.loggerOptions.errMaxSize,
+          this.loggerOptions.maxSize,
+          '200m'
+        ),
         maxFiles:
           this.loggerOptions.errMaxFiles ||
           this.loggerOptions.maxFiles ||
@@ -293,10 +307,11 @@ export class MidwayBaseLogger extends WinstonLogger implements IMidwayLogger {
           this.loggerOptions.disableSymlink
         ),
         symlinkName: this.loggerOptions.jsonLogName,
-        maxSize:
-          this.loggerOptions.jsonMaxSize ||
-          this.loggerOptions.maxSize ||
-          '200m',
+        maxSize: getMaxSize(
+          this.loggerOptions.jsonMaxSize,
+          this.loggerOptions.maxSize,
+          '200m'
+        ),
         maxFiles:
           this.loggerOptions.jsonMaxFiles ||
           this.loggerOptions.maxFiles ||

--- a/src/transport/fileStreamRotator.ts
+++ b/src/transport/fileStreamRotator.ts
@@ -4,7 +4,7 @@ import * as fs from 'fs';
 import * as path from 'path';
 import * as crypto from 'crypto';
 import * as EventEmitter from 'events';
-import { format, debuglog } from 'util';
+import { debuglog, format } from 'util';
 import * as dayjs from 'dayjs';
 import * as utc from 'dayjs/plugin/utc';
 import * as assert from 'assert';
@@ -577,18 +577,24 @@ export class FileStreamRotator {
 
       // 这里采用 1s 的防抖，避免过于频繁的获取文件大小
       const resetCurLogSize = debounce(() => {
-        const lastLogFileStats = fs.statSync(logfile);
-        if (lastLogFileStats.size > curSize) {
-          curSize = lastLogFileStats.size;
+        try {
+          const lastLogFileStats = fs.statSync(logfile);
+          if (lastLogFileStats.size > curSize) {
+            curSize = lastLogFileStats.size;
+          }
+          return false;
+        } catch (err) {
+          return true;
         }
       }, 1000);
 
       stream.write = (str, encoding) => {
-        resetCurLogSize();
+        const isCurLogRemoved = resetCurLogSize();
         const newDate = frequencyMetaData
           ? this.getDate(frequencyMetaData, dateFormat, options.utc)
           : curDate;
         if (
+          isCurLogRemoved ||
           (curDate && newDate !== curDate) ||
           (fileSize && curSize > fileSize)
         ) {

--- a/src/transport/fileStreamRotator.ts
+++ b/src/transport/fileStreamRotator.ts
@@ -577,15 +577,16 @@ export class FileStreamRotator {
 
       // 这里采用 1s 的防抖，避免过于频繁的获取文件大小
       const resetCurLogSize = debounce(() => {
+        let isCurLogRemoved = false;
         try {
           const lastLogFileStats = fs.statSync(logfile);
           if (lastLogFileStats.size > curSize) {
             curSize = lastLogFileStats.size;
           }
-          return false;
         } catch (err) {
-          return true;
+          isCurLogRemoved = true;
         }
+        return isCurLogRemoved;
       }, 1000);
 
       stream.write = (str, encoding) => {


### PR DESCRIPTION
1、支持maxSize设置为null，即不开启按大小轮转
2、防止pm2开启多实例时，当日志轮转并被压缩时，原日志文件被删除后，导致部分实例stat原日志文件抛出异常
3、按标准prettier部分代码格式