### PR TITLE
fix: 修复文件日志流监听器泄漏

### DIFF
--- a/src/transport/file.ts
+++ b/src/transport/file.ts
@@ -28,6 +28,8 @@ export class FileTransport
   protected bufSize = 0;
   protected buf = [];
   protected timer: NodeJS.Timeout;
+  private logRemovedHandler?: (params: { name: string }) => void;
+  private rotateHandler?: (oldFile: string) => void;
 
   constructor(
     protected readonly options: FileTransportOptions = {} as FileTransportOptions
@@ -79,8 +81,8 @@ export class FileTransport
       ...options,
     });
 
-    this.logStream.on('logRemoved', params => {
-      if (options.zippedArchive) {
+    if (options.zippedArchive) {
+      this.logRemovedHandler = params => {
         const gzName = params.name + '.gz';
         if (fs.existsSync(gzName)) {
           try {
@@ -91,11 +93,10 @@ export class FileTransport
           }
           return;
         }
-      }
-    });
+      };
+      this.logStream.on('logRemoved', this.logRemovedHandler);
 
-    if (options.zippedArchive) {
-      this.logStream.on('rotate', oldFile => {
+      this.rotateHandler = oldFile => {
         const oldFileExist = fs.existsSync(oldFile);
         const gzExist = fs.existsSync(oldFile + '.gz');
         if (!oldFileExist || gzExist) {
@@ -113,7 +114,8 @@ export class FileTransport
               fs.unlinkSync(oldFile);
             }
           });
-      });
+      };
+      this.logStream.on('rotate', this.rotateHandler);
     }
   }
 
@@ -152,6 +154,12 @@ export class FileTransport
     }
 
     if (this.logStream) {
+      if (this.logRemovedHandler) {
+        this.logStream.removeListener('logRemoved', this.logRemovedHandler);
+      }
+      if (this.rotateHandler) {
+        this.logStream.removeListener('rotate', this.rotateHandler);
+      }
       FileStreamRotatorManager.close(this.logStream);
       // 处理重复调用 close
       this.logStream = null;

--- a/src/transport/fileStreamRotator.ts
+++ b/src/transport/fileStreamRotator.ts
@@ -518,8 +518,8 @@ export class FileStreamRotatorManager {
       }
 
       stream = this.streamPool.get(options.filename);
-      let num = this.loggerRef.get(stream);
-      this.loggerRef.set(stream, num++);
+      const num = this.loggerRef.get(stream) ?? 0;
+      this.loggerRef.set(stream, num + 1);
     } else {
       stream = new FileStreamRotator().getStream(options);
     }

--- a/test/file.test.ts
+++ b/test/file.test.ts
@@ -1,8 +1,13 @@
 import { join } from 'path';
 import { fileExists, includeContent, removeFileOrDir, sleep } from './util';
 import { ConsoleTransport, FileTransport, MidwayLogger } from '../src';
+import { FileStreamRotatorManager } from '../src/transport/fileStreamRotator';
 
 describe('test/file.test.ts', function () {
+  afterEach(() => {
+    FileStreamRotatorManager.clear();
+  });
+
   it('should test file logger with buffer', async () => {
     const logsDir = join(__dirname, 'logs');
     await removeFileOrDir(logsDir);
@@ -47,4 +52,39 @@ describe('test/file.test.ts', function () {
 
     await removeFileOrDir(logsDir);
   });
-})
+
+  it('should release pooled stream listeners when transports close', async () => {
+    const logsDir = join(__dirname, 'listener-cleanup-logs');
+    await removeFileOrDir(logsDir);
+    const options = {
+      dir: logsDir,
+      fileLogName: 'listener-cleanup.log',
+      maxSize: '10m',
+      maxFiles: 5,
+      zippedArchive: true,
+      createSymlink: false,
+    };
+    const first = new FileTransport(options);
+    const second = new FileTransport(options);
+    const pooledStream = (first as any).logStream;
+
+    expect((second as any).logStream).toBe(pooledStream);
+    expect(pooledStream.listenerCount('logRemoved')).toBe(2);
+    expect(pooledStream.listenerCount('rotate')).toBe(2);
+
+    first.close();
+    expect(pooledStream.listenerCount('logRemoved')).toBe(1);
+    expect(pooledStream.listenerCount('rotate')).toBe(1);
+    expect(pooledStream.canWrite()).toBe(true);
+
+    second.close();
+    expect(pooledStream.listenerCount('logRemoved')).toBe(0);
+    expect(pooledStream.listenerCount('rotate')).toBe(0);
+
+    const third = new FileTransport(options);
+    expect((third as any).logStream).not.toBe(pooledStream);
+    third.close();
+
+    await removeFileOrDir(logsDir);
+  });
+});


### PR DESCRIPTION
## 问题

重复创建并关闭写入同一文件的 `MidwayLogger` 时，底层文件流会被复用，但引用计数没有正确增加，同时每个 `FileTransport` 注册的 `logRemoved`/`rotate` 监听器在关闭时未注销。

这会导致已关闭 transport 的监听器持续累积，并最终触发：

```text
MaxListenersExceededWarning: Possible EventEmitter memory leak detected.
11 logRemoved listeners added to [EventEmitter].
```

## 修改

- 将文件流引用计数从后置自增改为明确的 `num + 1`
- 仅在启用压缩归档时注册 `logRemoved` 和 `rotate` 监听器
- 保存每个 transport 注册的监听器，并在 `close()` 时注销
- 增加共享文件流回归测试，覆盖：
  - 两个 transport 复用同一个文件流
  - 关闭一个 transport 后，另一个仍可正常使用
  - 监听器按 transport 正确释放
  - 最后一个引用关闭后，文件流从池中移除

## 验证

- `jest test/file.test.ts --runInBand`：2 tests passed
- 普通测试（排除会主动调用 `process.exit()` 的既有 `stream-rotate.test.ts`）：57 tests passed
- `tsc --pretty`：通过
- `mwts check`：通过，只有上游原有的 2 条 unused parameter warning
- 原始 11 次创建/关闭最小复现脚本不再产生监听器警告
